### PR TITLE
Js lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,18 +178,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -254,9 +254,9 @@ checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
 name = "syn"
-version = "1.0.19"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
+checksum = "2010dd20d6200209c24f17022e34c73b8e79fb42180f8c9ca970a8dbc44acc8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -283,6 +283,6 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"

--- a/Features.md
+++ b/Features.md
@@ -31,21 +31,25 @@ Char, as is done in Haskell.
 | List Comprehension | |
 | List Iteration (for loop) | |
 
-Technically, Lists can currently be constructed in Spruce with ADTs as such:
+The Spruce approach to lists is experimental, and prone to change. This is the
+prelude definition of list:
 
 ```
-type List {
-    Cons(Float, List)
+type List(a) {
+    Cons(List(a), a)
     Nil
 }
 ```
 
-This is the list definition one might expect to see in functional languages.
-However, for performance reasons it probably makes more sense to back Spruce's
-lists with JavaScript lists. Ideally interfaces will make it possible for both
-versions of a list to be used in things like for loops. One of the main design
-goals of Spruce is to make list processing easy and expressive with a mix of
-functional and imperative concepts.
+Which is similar to how Haskell implements list, except with the two arguments
+of `Cons` swapped. The reasoning behind this is that JavaScript arrays (which
+Spruce arrays are directly backed by) have O(1) append time, and O(n) prepend
+time. This definition ensures that the `Cons` constructor works in constant
+time.
+
+While this rationale makes enough sense from a performance perspective, it has
+yet to be seen if this is a practical way to write software that operates on
+lists. Defining lists this way need not be set in stone.
 
 ## Functions
 

--- a/Features.md
+++ b/Features.md
@@ -26,7 +26,7 @@ Char, as is done in Haskell.
 | Feature | Status |
 |---------|--------|
 | Lists | :heavy_check_mark: |
-| JS-backed Lists | |
+| JS-backed Lists | :heavy_check_mark: |
 | List Indexing (Python-style) | |
 | List Comprehension | |
 | List Iteration (for loop) | |

--- a/samples/primes.sp
+++ b/samples/primes.sp
@@ -1,8 +1,8 @@
 filter(ls, fn) {
     case ls {
-        Cons(v, rest) -> {
+        Cons(rest, v) -> {
             case fn(v) {
-                True -> Cons(v, filter(rest, fn))
+                True -> Cons(filter(rest, fn), v)
                 False -> filter(rest, fn)
             }
         }
@@ -12,9 +12,9 @@ filter(ls, fn) {
 
 filter2(ls, fn, firstArg) {
     case ls {
-        Cons(v, rest) -> {
+        Cons(rest, v) -> {
             case fn(firstArg, v) {
-                True -> Cons(v, filter2(rest, fn, firstArg))
+                True -> Cons(filter2(rest, fn, firstArg), v)
                 False -> filter2(rest, fn, firstArg)
             }
         }
@@ -24,7 +24,7 @@ filter2(ls, fn, firstArg) {
 
 range(start, end) {
     case start < end {
-        True -> Cons(start, range(start + 1, end))
+        True -> Cons(range(start + 1, end), start)
         False -> Nil
     }
 }
@@ -34,7 +34,7 @@ isPrime(n) {
     factors = filter2(checkFactors, isFactor, n)
 
     case factors {
-        Cons(val, rest) -> False
+        Cons(rest, val) -> False
         Nil -> True
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -10,7 +10,7 @@ pub fn gen_prog(out: &mut fs::File, prog: &Prog, env: &Environment) {
     let js_helpers = fs::read_to_string("src/helper.js").expect("cannot read js helpers file");
     write!(out, "{}", js_helpers).expect("failed to write helpers");
 
-    for t in &prog.types {
+    for (_, t) in &prog.type_table.types {
         write!(out, "{}", gen_type(prog, env, t)).expect("failed to write line");
     }
 
@@ -26,11 +26,18 @@ pub fn gen_prog(out: &mut fs::File, prog: &Prog, env: &Environment) {
     write!(out, "\nconsole.log(main())").expect("failed to write line");
 }
 
-fn gen_type(prog: &Prog, env: &Environment, t: &TypeNode) -> String {
-    let mut output = format!("const {} = {{\n", t.val.name);
+fn gen_type(prog: &Prog, env: &Environment, t: &ADT) -> String {
+    let mut output = format!("const {} = {{\n", t.name);
 
-    for opt in &t.val.options {
-        output = append_line(&output, format!("{}: '{}',\n", opt.val.name.to_ascii_uppercase(), opt.val.name), 1);
+    let mut options = Vec::new();
+    for id in &t.values {
+        options.push(
+            (*prog.type_table.values.get(id).expect("dangling val id")).clone()
+        );
+    }
+
+    for opt in &options {
+        output = append_line(&output, format!("{}: '{}',\n", opt.name.to_ascii_uppercase(), opt.name), 1);
     }
 
     output = format!("{}}}\n", output);

--- a/src/helper.js
+++ b/src/helper.js
@@ -8,3 +8,9 @@ function _to_bool(b) {
         return [Bool.FALSE]
     }
 }
+
+function _push_and_copy(list, val) {
+    var new_list = list.map((x) => x);
+    new_list.push(val);
+    return new_list;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     let spruce_code: &String = &args[1];
     let spruce_path = Path::new(spruce_code);
 
-    let prelude = fs::read_to_string("prelude.sp").expect("cannot read prelude");
+    let prelude = fs::read_to_string("src/prelude.sp").expect("cannot read prelude");
     let unparsed_file = fs::read_to_string(spruce_path).expect(&format!("Cannot find file {}", spruce_code));
     let files = vec![(prelude.as_str(), String::from("prelude")), (unparsed_file.as_str(), String::from("main"))];
 

--- a/src/name_analysis.rs
+++ b/src/name_analysis.rs
@@ -216,7 +216,7 @@ pub struct InternalTypes {
 pub struct Prog {
     pub functions: Vec<FuncNode>,
     pub definitions: Vec<StmtNode>,
-    pub types: Vec<TypeNode>,
+    //pub types: Vec<TypeNode>,
     pub symbol_table: SymbolTable,
     pub type_table: TypeTableExt,
     pub internal_types: InternalTypes
@@ -250,7 +250,7 @@ pub fn name_analysis(prog: parser::Prog) -> Result<Prog, NameErr> {
     let out_prog = Prog {
         functions: funcs, 
         definitions: defs,
-        types: types,
+        //types: types,
         symbol_table: sym_table,
         type_table: type_table.to_ext(),
         internal_types: internal_types

--- a/src/name_analysis.rs
+++ b/src/name_analysis.rs
@@ -736,7 +736,7 @@ pub enum TypeID {
     Prim(String),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ADTValue {
     pub id: ADTValID,
     pub name: String,
@@ -748,7 +748,8 @@ pub struct ADTValue {
 pub struct ADT {
     pub id: ADTID,
     pub type_params: Vec<TParamID>,
-    pub name: String
+    pub name: String,
+    pub values: Vec<ADTValID>
 }
 
 #[derive(Debug, PartialEq)]
@@ -788,21 +789,18 @@ impl TypeTable {
     }
 
     fn add_type(&mut self, name: &String, params: Vec<TParamID>) {
-        let new_adt = ADT {name: name.clone(), id: self.next_type_id, type_params: params};
+        let new_adt = ADT {name: name.clone(), id: self.next_type_id, type_params: params, values: vec![]};
         self.next_type_id += 1;
         self.types.insert(name.clone(), new_adt);
     }
 
     fn add_value(&mut self, name: &String, args: &Vec<TypeID>, data_type: &String) {
-        let mut r = self.types.get_mut(data_type);
-        match r {
-            Some(adt) => {
-                let new_val = ADTValue {name: name.clone(), args: (*args).clone(), data_type: adt.id, id: self.next_val_id};
-                self.next_val_id += 1;
-                self.values.insert(new_val.name.clone(), new_val);
-            }
-            None => unreachable!()
-        }
+        let mut adt = self.types.get_mut(data_type).expect("unreachable");
+        adt.values.push(self.next_val_id);
+
+        let new_val = ADTValue {name: name.clone(), args: (*args).clone(), data_type: adt.id, id: self.next_val_id};
+        self.next_val_id += 1;
+        self.values.insert(new_val.name.clone(), new_val);
     }
 
     fn add_tparam(&mut self, name: &String) -> TParamID {

--- a/src/prelude.sp
+++ b/src/prelude.sp
@@ -27,9 +27,9 @@ type List(a) {
     Nil
 }
 
-map(ls, fn) {
+listMap(ls, fn) {
     case ls {
-        Cons(rest, val) -> Cons(map(rest, fn), val)
+        Cons(rest, val) -> Cons(listMap(rest, fn), val)
         Nil -> Nil
     }
 }


### PR DESCRIPTION
This PR introduces new codgen rules to have plain arrays back Spruce arrays. In a benchmark on computing the first 10000 primes, this produced a 3.5x speedup from old (non-special-cased) arrays.

Types were also removed from the ASTs emitted from name analysis (still present in parser ASTs) as this information was already in the type table. Additionally, `Environment` now also tracks case expr types, which allows special casing for arrays in codegen.

 While this was an improvement, significant work still exists in optimizing arrays. The biggest problem right now is that `Cons` always makes a copy of the list before pushing, as the list passed to cons might be used later and thus can't be mutated. One option would be to track if this is the last usage of that identifier, and if so to not make the copy.