### PR TITLE
Type Annotations

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -64,7 +64,7 @@ lists. Defining lists this way need not be set in stone.
 
 | Feature | Status |
 |---------|--------|
-| Type Annotations | |
+| Type Annotations | :heavy_check_mark: |
 | Type Inference | :heavy_check_mark: |
 | Type Aliases | |
 | Typeclasses | |
@@ -128,7 +128,7 @@ statements.
 | Indentation | :heavy_check_mark: |
 | Output Optimization | |
 
-The compiler currently however generates javascript that faithfully executes
+The compiler currently generates javascript that faithfully executes
 the instructions provided by the source Spruce. However, no optimization is
 done on this output, which is of course very important if we want anyone to
 seriously consider using Spruce. Compier optimization is a massive topic

--- a/samples/primes.sp
+++ b/samples/primes.sp
@@ -1,4 +1,4 @@
-filter(ls, fn) {
+filter(ls: List(a), fn: (a) -> Bool) -> List(a) {
     case ls {
         Cons(rest, v) -> {
             case fn(v) {
@@ -22,14 +22,14 @@ filter2(ls, fn, firstArg) {
     }
 }
 
-range(start, end) {
+range(start: Int, end: Int) -> List(Int) {
     case start < end {
         True -> Cons(range(start + 1, end), start)
         False -> Nil
     }
 }
 
-isPrime(n) {
+isPrime(n: Int) -> Bool {
     checkFactors = range(2, n)
     factors = filter2(checkFactors, isFactor, n)
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -51,10 +51,10 @@ fn gen_func(prog: &Prog, env: &Environment, func_node: &FuncNode, indent: usize)
 
     let body_indent = indent + 1;
 
-    func.args.first().as_ref().map(|arg| {
+    func.args.first().as_ref().map(|(arg, _ann)| {
         output = format!("{}{}", output, gen_sym(&prog.symbol_table, arg));
     });
-    for arg in func.args.iter().skip(1) {
+    for (arg, _ann) in func.args.iter().skip(1) {
         output = format!("{}, {}", output, gen_sym(&prog.symbol_table, arg));
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,3 +201,55 @@ main() {
     let res = compile(files);
     assert_eq!(res.is_ok(), false);
 }
+
+#[test]
+fn test_annotations() {
+    let pass_prog = "
+type FooBar(a, b) {
+    Foo(a)
+    Bar(b)
+}
+
+func(fb: FooBar(a, Bool)) -> Bool {
+    case fb {
+        Foo(v) -> True
+        Bar(b) -> b
+    }
+}
+";
+
+    let prelude = fs::read_to_string("src/prelude.sp").expect("cannot read prelude");
+    let files = vec![(prelude.as_str(), String::from("prelude")), (pass_prog, String::from("Main"))];
+    let res = compile(files);
+    assert_eq!(res.is_ok(), true);
+
+    let fail_prog = "
+type FooBar(a, b) {
+    Foo(a)
+    Bar(b)
+}
+
+func(fb: FooBar(Bool, Int)) -> Bool {
+    case fb {
+        Foo(v) -> True
+        Bar(b) -> b
+    }
+}
+";
+
+    let prelude = fs::read_to_string("src/prelude.sp").expect("cannot read prelude");
+    let files = vec![(prelude.as_str(), String::from("prelude")), (fail_prog, String::from("Main"))];
+    let res = compile(files);
+    assert_eq!(res.is_ok(), false);
+
+    let fail_prog = "
+badId(x: a) -> b {
+    x
+}
+";
+
+    let prelude = fs::read_to_string("src/prelude.sp").expect("cannot read prelude");
+    let files = vec![(prelude.as_str(), String::from("prelude")), (fail_prog, String::from("Main"))];
+    let res = compile(files);
+    assert_eq!(res.is_ok(), false);
+}

--- a/src/name_analysis.rs
+++ b/src/name_analysis.rs
@@ -399,7 +399,7 @@ fn check_function(table: &mut SymbolTable, types: &TypeTable, func: &parser::Fun
     table.push_layer();
 
     let mut arg_symbols = Vec::new();
-    for arg in &func.val.args {
+    for (arg, ann) in &func.val.args {
         match table.attempt_insert(&arg, SymbolType::Const) {
             Some(id) => {
                 arg_symbols.push(id);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -205,10 +205,25 @@ pub struct TypeOptionNode {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum TypeAnnotation {
+    Unit,
+    ADT(String, Vec<Box<TypeAnnotationNode>>),
+    TVar(String),
+    Func(Vec<Box<TypeAnnotationNode>>, Box<TypeAnnotationNode>)
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TypeAnnotationNode {
+    pub val: TypeAnnotation,
+    pub info: NodeInfo
+}
+
+#[derive(Debug, PartialEq)]
 pub struct Func {
     pub name: String,
-    pub args: Vec<String>,
-    pub body: BodyNode
+    pub args: Vec<(String, Option<TypeAnnotationNode>)>,
+    pub body: BodyNode,
+    pub out_ann: Option<TypeAnnotationNode>
 }
 
 #[derive(Debug, PartialEq)]
@@ -428,6 +443,50 @@ fn to_stmt(stmt: Pair<Rule>, file_name: &String) -> StmtNode {
     }
 }
 
+fn to_type_annotation(mut p: Pair<Rule>, file_name: &String) -> TypeAnnotationNode {
+    let ann_span = p.as_span();
+    let type_ann = match p.as_rule() {
+        Rule::unit => TypeAnnotation::Unit,
+        Rule::tvar => TypeAnnotation::TVar(
+            String::from(p.as_str())
+        ),
+        Rule::adt => {
+            let mut children = p.into_inner();
+            let id = String::from(
+                children.next().unwrap().as_str()
+            );
+
+            let mut args = Vec::new();
+            for arg in children {
+                args.push(
+                    Box::from(to_type_annotation(arg, file_name))
+                );
+            }
+            TypeAnnotation::ADT(id, args)
+        }
+        Rule::func => {
+            let mut children = p.into_inner();
+            let mut sub_exprs = Vec::new();
+            for c in children {
+                sub_exprs.push(
+                    Box::from(to_type_annotation(c, file_name))
+                );
+            }
+
+            let out = sub_exprs.pop().expect("unreachable");
+            TypeAnnotation::Func(sub_exprs, out)
+        }
+        _ => unreachable!()
+    };
+    TypeAnnotationNode {
+        val: type_ann,
+        info: NodeInfo {
+            span: Span::from(ann_span),
+            file: file_name.clone()
+        }
+    }
+}
+
 fn to_func(mut p: Pair<Rule>, file_name: &String) -> FuncNode {
     let func_span = p.as_span();
     let mut func = p.into_inner();
@@ -436,8 +495,29 @@ fn to_func(mut p: Pair<Rule>, file_name: &String) -> FuncNode {
 
     let args = func.next().unwrap();
     let mut arg_vec = Vec::new();
+    let mut out_ann = None;
     for arg in args.into_inner() {
-        arg_vec.push(String::from(arg.as_str()));
+        match arg.as_rule() {
+            Rule::fn_arg => {
+                let mut arg_parts = arg.into_inner();
+                let id = String::from(
+                    arg_parts.next().unwrap().as_str()
+                );
+                let ann = match arg_parts.next() {
+                    Some(annotation) => {
+                        Some(to_type_annotation(annotation, file_name))
+                    }
+                    None => {
+                        None
+                    }
+                };
+                arg_vec.push((id, ann));
+            }
+            Rule::func | Rule::unit | Rule::adt | Rule::tvar => {
+                out_ann = Some(to_type_annotation(arg, file_name))
+            }
+            _ => unreachable!()
+        }
     }
 
     let body = to_body(func.next().unwrap(), file_name);
@@ -445,7 +525,8 @@ fn to_func(mut p: Pair<Rule>, file_name: &String) -> FuncNode {
     let func = Func {
         name: id,
         args: arg_vec,
-        body: body
+        body: body,
+        out_ann: out_ann
     };
 
     FuncNode {

--- a/src/prelude.sp
+++ b/src/prelude.sp
@@ -15,7 +15,7 @@ type Maybe(a) {
     Nothing
 }
 
-andThen(m, fn) {
+andThen(m: Maybe(a), fn: (a) -> Maybe(b)) -> Maybe(b) {
     case m {
         Just(val) -> fn(val)
         Nothing   -> Nothing
@@ -27,9 +27,9 @@ type List(a) {
     Nil
 }
 
-listMap(ls, fn) {
+listMap(ls: List(a), fn: (a) -> b) -> List(b) {
     case ls {
-        Cons(rest, val) -> Cons(listMap(rest, fn), val)
+        Cons(rest, val) -> Cons(listMap(rest, fn), fn(val))
         Nil -> Nil
     }
 }

--- a/src/prelude.sp
+++ b/src/prelude.sp
@@ -3,7 +3,7 @@ type Bool {
     False
 }
 
-not(b) {
+not(b: Bool) -> Bool {
     case b {
         True -> False
         False -> True

--- a/src/spruce.pest
+++ b/src/spruce.pest
@@ -3,36 +3,39 @@ file = _{ SOI ~ (top_stmt | empty_line)* ~ EOI }
 top_stmt = _{ ( function_decl | type_decl | assign ) ~ "\n" }
 stmt = _{ ( assign | fn_call | case ) ~ "\n" }
 
-type_decl = { "type" ~ id ~ type_params ~ "{\n" ~ (type_option ~ "\n")+ ~ "}" }
-type_params = { ("(" ~ id ~ ("," ~ id)* ~ ")")? }
-type_option = { id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
+type_decl = { "type" ~ up_id ~ type_params ~ "{\n" ~ (type_option ~ "\n")+ ~ "}" }
+type_params = { ("(" ~ lo_id ~ ("," ~ lo_id)* ~ ")")? }
+type_option = { up_id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
 
-type_id = { id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
+type_id = { up_id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? | lo_id }
 
-function_decl = { id ~ fn_args ~ "{\n" ~ body ~ "}" }
-fn_args = { "(" ~ (id ~ ("," ~ id)* )? ~ ")" }
+function_decl = { lo_id ~ fn_args ~ "{\n" ~ body ~ "}" }
+fn_args = { "(" ~ (lo_id ~ ("," ~ lo_id)* )? ~ ")" }
 
 assign = { target ~ "=" ~ valued }
 
-target = _{ mutable_tgt | update_tgt | id }
-mutable_tgt = { "mut" ~ id }
-update_tgt = { id ~ ":" }
+target = _{ mutable_tgt | update_tgt | lo_id }
+mutable_tgt = { "mut" ~ lo_id }
+update_tgt = { lo_id ~ ":" }
 
 // something that can be reduced to a value
 valued = _{ case | expr }
 
 case = { "case" ~ expr ~ "{\n" ~ case_option+ ~ "}" }
 case_option = { case_pattern ~ "->" ~ (expr | "{\n" ~ body ~ "}") ~ "\n" }
-case_pattern = { id ~ ( "(" ~ id ~ ( "," ~ id )*  ~ ")")? }
+case_pattern = { up_id ~ ( "(" ~ lo_id ~ ( "," ~ lo_id )*  ~ ")")? }
 
 body = { (stmt | empty_line)* ~ (valued ~ "\n")? }
 
 expr = { term ~ (operation ~ term)* }
-term = _{ fn_call | id | num | "(" ~ expr ~ ")" }
+term = _{ fn_call | val_call | id | num | "(" ~ expr ~ ")" }
 
-fn_call = { id ~ "(" ~ (expr ~ ("," ~ expr)* )? ~ ")" }
+fn_call = { lo_id ~ "(" ~ (expr ~ ("," ~ expr)* )? ~ ")" }
+val_call = { up_id ~ "(" ~ (expr ~ ("," ~ expr)* )? ~ ")" }
 
-id = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
+id = _{ up_id | lo_id }
+up_id = @{ ASCII_ALPHA_UPPER ~ ASCII_ALPHANUMERIC* }
+lo_id = @{ ASCII_ALPHA_LOWER ~ ASCII_ALPHANUMERIC* }
 
 empty_line = _{ "\n" }
 

--- a/src/spruce.pest
+++ b/src/spruce.pest
@@ -9,20 +9,23 @@ type_option = { up_id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
 
 type_id = { up_id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? | lo_id }
 
-// type annotation definitions
-type_ann = { fn |}
-    unit = { "()" }
-    fn = { "(" ~ (type_ann ~ ("," ~ type_ann)*)? ~ ")" ~ "->" ~ type_ann }
-
-
 function_decl = { lo_id ~ fn_args ~ "{\n" ~ body ~ "}" }
-fn_args = { "(" ~ (lo_id ~ ("," ~ lo_id)* )? ~ ")" }
+fn_args = { "(" ~ (fn_arg ~ ("," ~ fn_arg)*)? ~ ")" ~ ("->" ~ type_ann)? }
+fn_arg = { lo_id ~ (":" ~ type_ann)? }
 
 assign = { target ~ "=" ~ valued }
 
 target = _{ mutable_tgt | update_tgt | lo_id }
 mutable_tgt = { "mut" ~ lo_id }
 update_tgt = { lo_id ~ ":" }
+
+// type annotation definitions
+type_ann = _{ func | unit | adt | tvar }
+    unit = { "()" }
+    adt = { up_id ~ ("(" ~ type_ann ~ ("," ~ type_ann)* ~ ")")? }
+    tvar = { lo_id }
+    func = { "(" ~ (type_ann ~ ("," ~ type_ann)*)? ~ ")" ~ "->" ~ type_ann }
+
 
 // something that can be reduced to a value
 valued = _{ case | expr }

--- a/src/spruce.pest
+++ b/src/spruce.pest
@@ -9,6 +9,12 @@ type_option = { id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
 
 type_id = { id ~ ("(" ~ type_id ~ ("," ~ type_id)* ~ ")")? }
 
+// type annotation definitions
+type_ann = { fn |}
+    unit = { "()" }
+    fn = { "(" ~ (type_ann ~ ("," ~ type_ann)*)? ~ ")" ~ "->" ~ type_ann }
+
+
 function_decl = { id ~ fn_args ~ "{\n" ~ body ~ "}" }
 fn_args = { "(" ~ (id ~ ("," ~ id)* )? ~ ")" }
 


### PR DESCRIPTION
This PR will add type annotations for functions, with the format:

```
map(ls: List(a), fn: (a) -> b) -> List(b)
```

Which takes a more rust-like type annotation approach, but with more succinct generic types a la Haskell. Type annotations will be optional, and incredibly useful in the future to specify interop functions. Note that only complete type annotations will be verified by the compiler, which is definitely dangerous and misleading behavior that we should improve at some point.